### PR TITLE
Updated extension to Chrome manifest version 2

### DIFF
--- a/background.html
+++ b/background.html
@@ -1,9 +1,0 @@
-<html>
-<script>
-chrome.extension.onRequest.addListener(function (request, sender) { 
-  if (request == "show_page_action"){
-	  chrome.pageAction.show(sender.tab.id);
-	} 
-});
-</script>
-</html>

--- a/background.js
+++ b/background.js
@@ -1,0 +1,5 @@
+chrome.extension.onRequest.addListener(function (request, sender) { 
+  if (request == "show_page_action"){
+	  chrome.pageAction.show(sender.tab.id);
+	} 
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,11 @@
 {
   "name": "Drupal for Chrome",
-  "version": "0.6",
+  "version": "0.7",
   "description": "Provides Drupal specific debugging information for chrome.",
   "permissions": ["tabs"],
-  "background_page": "background.html",
+  "background": {
+	"scripts": ["background.js"]
+  },
   "icons": { "48": "images/icon48.png",
           "128": "images/icon128.png" },
   "content_scripts": [
@@ -16,5 +18,6 @@
     "default_icon": "images/icon19.png",
     "default_title": "Drupal for Chrome Enabled",
     "default_popup": "popup.html"
-  }
+  },
+  "manifest_version": 2
 }


### PR DESCRIPTION
It'd be nice if you can pull this in and re-publish with Chrome.

I was also missing the https functionality, and had to hunt for a while to find this repo so I could upgrade from the published 0.4 version to 0.6 (only in your git repo).

As part of getting the unpacked version of this from git into Chrome, I had to update the manifest which necessitated a couple other minor changes. Thus my fork has a bumped version number.

-Stephen
